### PR TITLE
Add Security-Extended CodeQL Query Packs for JS and CS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        #queries: security-extended
+        queries: security-extended
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
Flagged the medium precision query for A7 - [stored XSS](https://github.com/github/codeql/blob/3059ce307009d40afb690aa712c96e422cf76753/csharp/ql/src/Security%20Features/CWE-079/StoredXSS.ql)

Found: https://github.com/vulna-felickz/OwaspTop10Examples/security/code-scanning/19

A7 - Cross-Site Scripting
An example of reflected XSS is found in our index.cshtml in Views\BlogEntries\Index.cshtml reads a parameter from the query string - and injects it directly into the the dom innerHtml. Fixed in the same view by using textContent instead of innerHTml.

An example of stored XSS is found in our index.cshtml in Views\Comments\Index.cshtml where we @Html.Raw(item.Body) which, if there is a <script> tag embedded into the comment will load every time.

