### PR TITLE
Enable security-experimental

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,12 +47,13 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        tools: latest
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: security-extended
+        queries: security-experimental
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)


### PR DESCRIPTION
[security-experimental](https://github.com/github/codeql/blob/cd596403a0e14a7cd6ef2b548ca89dc596eafe81/misc/suite-helpers/security-experimental-selectors.yml)

[Before](https://github.com/vulna-felickz/OwaspTop10Examples/actions/runs/4055416032/jobs/6978526045): 
```
  Error: The workflow property "queries.uses" is invalid: must be a built-in suite (security-extended or security-and-quality), a relative path, or be of the form "owner/repo[/path]@ref"
   Found: security-experimental
  Error: The workflow property "queries.uses" is invalid: must be a built-in suite (security-extended or security-and-quality), a relative path, or be of the form "owner/repo[/path]@ref"
   Found: security-experimental
      at addBuiltinSuiteQueries (/home/runner/work/_actions/github/codeql-action/v2/lib/config-utils.js:144:15)
      at parseQueryUses (/home/runner/work/_actions/github/codeql-action/v2/lib/config-utils.js:243:22)
      at addQueriesAndPacksFromWorkflow (/home/runner/work/_actions/github/codeql-action/v2/lib/config-utils.js:500:33)
      at getDefaultConfig (/home/runner/work/_actions/github/codeql-action/v2/lib/config-utils.js:536:19)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at async Object.initConfig (/home/runner/work/_actions/github/codeql-action/v2/lib/config-utils.js:927:18)
      at async initConfig (/home/runner/work/_actions/github/codeql-action/v2/lib/init.js:54:20)
      at async run (/home/runner/work/_actions/github/codeql-action/v2/lib/init-action.js:131:18)
      at async runWrapper (/home/runner/work/_actions/github/codeql-action/v2/lib/init-action.js:208:9)
```

After:

Bad HTML filtering regexp
High
This regular expression only parses --> and not --!> as a HTML comment end tag.
[Show more details](https://github.com/vulna-felickz/OwaspTop10Examples/security/code-scanning/36)